### PR TITLE
Fixes in Files and Implemenation of navigationObserver for automatic Screen Name Tagging

### DIFF
--- a/lib/flutter_occlusion.dart
+++ b/lib/flutter_occlusion.dart
@@ -1,7 +1,3 @@
-
-
-import 'package:flutter/cupertino.dart';
-
 class FlutterUxOcclusionKeys {
   static const screens = "screens";
   static const name = "name";
@@ -10,12 +6,9 @@ class FlutterUxOcclusionKeys {
   static const config = "config";
 }
 
-enum UXOcclusionType {
-  none, occludeAllTextFields, overlay, blur, unknown
-}
+enum UXOcclusionType { none, occludeAllTextFields, overlay, blur, unknown }
 
 abstract class FlutterUXOcclusion {
-
   String get name;
   UXOcclusionType get type;
   List<String> screens = [];

--- a/lib/flutter_uxcam.dart
+++ b/lib/flutter_uxcam.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_uxcam/flutter_occlusion.dart';
 

--- a/lib/flutter_uxcam_observer.dart
+++ b/lib/flutter_uxcam_observer.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_uxcam/flutter_uxcam.dart';
+
+/// Here using NavigatorObserver instead of [RouteObserver] because 
+/// [RouteObserver] only works for Navigator 1.0 and will log nothing 
+/// or perform no calls in case of Navigator 2.0.
+class FlutterUxcamNavigatorObserver extends NavigatorObserver {
+  /// Using this approach as we need to keep track of screens
+  /// before this one and keep track of screens previous to the
+  /// current one.
+  List<String> screenNames = [];
+
+  /// Using this to chech for and store latest Screen Name
+  String taggingScreen = '';
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    screenNames.add(route.settings.name!);
+    setAndTaggingScreenName();
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    screenNames.remove(newRoute?.settings.name);
+    setAndTaggingScreenName();
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    screenNames.remove(route.settings.name);
+    setAndTaggingScreenName();
+    super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route route, Route? previousRoute) {
+    screenNames.remove(route.settings.name);
+    setAndTaggingScreenName();
+    super.didRemove(route, previousRoute);
+  }
+
+  /// This function will just perform operation for setting [taggingScreen] and
+  /// depeding on the value of  [taggingScreen] will either discard or perform
+  /// [FlutterUxcam.tagScreenName] operation.
+  void setAndTaggingScreenName() {
+    taggingScreen = screenNames.isNotEmpty ? screenNames.last : '';
+    if (taggingScreen.isNotEmpty) {
+      FlutterUxcam.tagScreenName(taggingScreen);
+    }
+  }
+}

--- a/lib/uxblur.dart
+++ b/lib/uxblur.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:flutter_uxcam/flutter_occlusion.dart';
 
 class FlutterUxBlurKeys {
@@ -7,12 +5,9 @@ class FlutterUxBlurKeys {
   static const hideGestures = "hideGestures";
 }
 
-enum BlurType {
-  gaussian, stack, box, bokeh
-}
+enum BlurType { gaussian, stack, box, bokeh }
 
 class FlutterUXBlur extends FlutterUXOcclusion {
-
   int blurRadius = 10;
   bool hideGestures = true;
 
@@ -26,17 +21,17 @@ class FlutterUXBlur extends FlutterUXOcclusion {
 
   @override
   Map<String, dynamic>? get configuration => {
-    FlutterUxBlurKeys.blurRadius: blurRadius,
-    FlutterUxBlurKeys.hideGestures: hideGestures
-  };
+        FlutterUxBlurKeys.blurRadius: blurRadius,
+        FlutterUxBlurKeys.hideGestures: hideGestures
+      };
 
-  FlutterUXBlur({
-    int blurRadius = 10,
-    BlurType blurType = BlurType.gaussian,
-    bool hideGestures = true,
-    List<String> screens = const [],
-    bool excludeMentionedScreens = false
-  }): super(screens, excludeMentionedScreens) {
+  FlutterUXBlur(
+      {int blurRadius = 10,
+      BlurType blurType = BlurType.gaussian,
+      bool hideGestures = true,
+      List<String> screens = const [],
+      bool excludeMentionedScreens = false})
+      : super(screens, excludeMentionedScreens) {
     this.blurRadius = blurRadius;
     this.blurType = blurType;
     this.hideGestures = hideGestures;
@@ -44,12 +39,14 @@ class FlutterUXBlur extends FlutterUXOcclusion {
 
   String getName(BlurType type) {
     switch (type) {
-      case BlurType.gaussian: return "gaussianBlur";
-      case BlurType.stack: return "stackBlur";
-      case BlurType.box: return "boxBlur";
-      case BlurType.bokeh: return "bokehBlur";
-
-
+      case BlurType.gaussian:
+        return "gaussianBlur";
+      case BlurType.stack:
+        return "stackBlur";
+      case BlurType.box:
+        return "boxBlur";
+      case BlurType.bokeh:
+        return "bokehBlur";
     }
   }
 }

--- a/lib/uxoverlay.dart
+++ b/lib/uxoverlay.dart
@@ -7,31 +7,34 @@ class FlutterUxOverlayKeys {
 }
 
 class FlutterUXOverlay extends FlutterUXOcclusion {
-
-
   Color color = Colors.red;
   bool hideGestures = true;
 
   @override
-  String get name => 'UXOcclusionTypeOverlay'; // not used.. only to make it compatible with blur
+  String get name =>
+      'UXOcclusionTypeOverlay'; // not used.. only to make it compatible with blur
 
   @override
   UXOcclusionType get type => UXOcclusionType.overlay;
 
   @override
   Map<String, dynamic>? get configuration => {
-    FlutterUxOverlayKeys.color: [color.red, color.green, color.blue, color.alpha],
-    FlutterUxOverlayKeys.hideGestures: hideGestures
-  };
+        FlutterUxOverlayKeys.color: [
+          color.red,
+          color.green,
+          color.blue,
+          color.alpha
+        ],
+        FlutterUxOverlayKeys.hideGestures: hideGestures
+      };
 
-  FlutterUXOverlay({
-    Color color = Colors.red,
-    bool hideGestures = true,
-    List<String> screens = const [],
-    bool excludeMentionedScreens = false
-  }): super(screens, excludeMentionedScreens) {
+  FlutterUXOverlay(
+      {Color color = Colors.red,
+      bool hideGestures = true,
+      List<String> screens = const [],
+      bool excludeMentionedScreens = false})
+      : super(screens, excludeMentionedScreens) {
     this.color = color;
     this.hideGestures = hideGestures;
   }
-
 }


### PR DESCRIPTION
Addresses #17

The PR brings `FlutterUxcamNavigatorObserver` that helps to automatically tag screen names in Flutter.

This PR brings a solution for Automatic Screen Name Tagging where the File added will handle screen tagging in case for both Navigator 1.0 and Navigator 2.0 (using goRouter). 

```dart
import 'package:flutter/material.dart';
import 'package:flutter_uxcam/observer.dart';

MaterialApp(
   ...
   navigatorObservers: [
     FlutterUxcamNavigatorObserver(),
   ],
   ...
 )
 ```

or as there is no option for navigationObserver in `MaterialApp.router( ... )`
```dart
final GoRouter router = GoRouter(
    ...
    observers: [
      FlutterUxcamNavigatorObserver(),
    ],
    ...
```

See also:
  - [Flutter - NavigatorObserver](https://api.flutter.dev/flutter/widgets/NavigatorObserver-class.html)
  
Thanks to @romatallinn whose PR has triggered to get this solution 
PR: #18 

Final Output in an app using this approach:

https://user-images.githubusercontent.com/113590027/204495512-e779613d-e39c-4799-88b6-e35cb35734f0.mov

