### PR TITLE
Include namespace property for Gradle 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 33
 
+    if (project.android.hasProperty("namespace")) {
+        namespace("com.uxcam.flutteruxcam")
+    }
+
     defaultConfig {
         minSdkVersion 21
     }


### PR DESCRIPTION
Hi all,

Building a project with AGP8+ requires the `namespace` property to be defined in all dependency `build.gradle` files. The conditional statement keeps it backwards compatible with any previous AGP versions. 

Closes #49 

Thanks for the great package!
David
