### PR TITLE
add fun to start and stop timer

### DIFF
--- a/lib/src/widgets/occlude_wrapper.dart
+++ b/lib/src/widgets/occlude_wrapper.dart
@@ -21,28 +21,28 @@ class OccludeWrapper extends StatefulWidget {
 class _OccludeWrapperState extends State<OccludeWrapper> {
   late OccludePoint occludePoint;
   final GlobalKey _widgetKey = GlobalKey();
-  bool enableOcclusion = true;
+  Timer? _timer = null;
 
-  @override
-  void initState() {
-    Timer.periodic(const Duration(milliseconds: 50), (_) {
-      if (enableOcclusion) {
-        getOccludePoints();
-      }
+  void startTimer() {
+    _timer = Timer.periodic(const Duration(milliseconds: 50), (_) {
+      getOccludePoints();
     });
-    super.initState();
+  }
+
+  void cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+    FlutterUxcam.occludeRectWithCoordinates(0, 0, 0, 0);
   }
 
   @override
   Widget build(BuildContext context) {
     return ScreenLifecycle(
       onFocusLost: () {
-        if (mounted) {
-          enableOcclusion = false;
-        }
+        cancelTimer();
       },
       onFocusGained: () {
-        enableOcclusion = true;
+        startTimer();
       },
       child: Container(
         key: _widgetKey,


### PR DESCRIPTION
The Timer weren't canceled even when the occlude wrapper widget get disposed. 
I have implemented two functions: one to start the timer when the occlude wrapper widget gains focus, and another to stop timer when the widget loses focus.