### PR TITLE
call getOccludePoints() immediately on startTimer()

### DIFF
--- a/lib/src/widgets/occlude_wrapper.dart
+++ b/lib/src/widgets/occlude_wrapper.dart
@@ -24,6 +24,7 @@ class _OccludeWrapperState extends State<OccludeWrapper> {
   Timer? _timer = null;
 
   void startTimer() {
+    getOccludePoints();
     _timer = Timer.periodic(const Duration(milliseconds: 50), (_) {
       getOccludePoints();
     });


### PR DESCRIPTION
as the first tick will occur only after 50 milliseconds, call getOccludePoints() immediately before the timer instance is created.