### PR TITLE
Call getOccludePoints() inside initState()

### DIFF
--- a/lib/src/widgets/occlude_wrapper.dart
+++ b/lib/src/widgets/occlude_wrapper.dart
@@ -37,6 +37,14 @@ class _OccludeWrapperState extends State<OccludeWrapper> {
   }
 
   @override
+  void initState() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      getOccludePoints();
+    });
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ScreenLifecycle(
       onFocusLost: () {

--- a/lib/src/widgets/occlude_wrapper.dart
+++ b/lib/src/widgets/occlude_wrapper.dart
@@ -24,6 +24,7 @@ class _OccludeWrapperState extends State<OccludeWrapper> {
   Timer? _timer = null;
 
   void startTimer() {
+    getOccludePoints();
     _timer = Timer.periodic(const Duration(milliseconds: 50), (_) {
       getOccludePoints();
     });


### PR DESCRIPTION
- call getOccludePoints() on initState(), to mitigate the risk of exposing occluded views during transactions, as it will get called before build method. 
- Since initState() is invoked before the layouts are fully rendered, a post-layout callback has been added to ensure proper execution 