### PR TITLE
Migrate to Flutter 3.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 Version | Changes |
 -- | -- |
+2.5.9           | Migrated to latest Flutter release 3.29.0<br/>Enhance Memory Usage |
 2.5.8           | Updated iOS SDK to 3.6.21 and Android SDK to 3.6.37 |
 2.5.7           | Updated iOS SDK to 3.6.20 and Android SDK to 3.6.36 |
 2.5.6           | Updated iOS SDK to 3.6.19 and Android SDK to 3.6.34 |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  stack_trace: ^1.11.1
+  stack_trace: ^1.12.1
   visibility_detector: ^0.4.0+2
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
- Remove Registrar Dependency:
-- Eliminate the deprecated Registrar and use FlutterPlugin and ActivityAware for proper plugin registration.

- Convert Static Activity to Instance Variable:
-- Avoid static activity references to prevent **Memory Leak Risks** and ensure correct activity handling.

- Use FlutterPlugin Lifecycle Methods:
-- Set up the method channel in onAttachedToEngine and clean up in onDetachedFromEngine.

- Handle Activity Lifecycle:
-- Properly manage activity attachment/detachment using ActivityAware methods.

this PR solves
#83
#82
#76 